### PR TITLE
Use docker-compose volumes instead of copying files over

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM python:bullseye
 
 WORKDIR /static
 
-COPY . /static
+COPY requirements.txt /static/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-CMD ["gunicorn", "--bind",  "0.0.0.0:5000", "-w", "8", "src.main:app"]


### PR DESCRIPTION
This is so that we can change markdown files to have metadata tags, for example, and have them be persistent on machine.